### PR TITLE
Refactor(core): assertions, Task rename, Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lazysourcea.lazysourcea project template
+# lazysourcea project template
 
 This is a project template for a greenfield Java project. It's named after the Java mascot _Duke_. Given below are instructions on how to use it.
 
@@ -13,7 +13,7 @@ Prerequisites: JDK 17, update Intellij to the most recent version.
    1. If there are any further prompts, accept the defaults.
 1. Configure the project to use **JDK 17** (not other versions) as explained in [here](https://www.jetbrains.com/help/idea/sdk.html#set-up-jdk).<br>
    In the same dialog, set the **Project language level** field to the `SDK default` option.
-1. After that, locate the `src/main/java/lazysourcea.lazysourcea.java` file, right-click it, and choose `Run lazysourcea.lazysourcea.main()` (if the code editor is showing compile errors, try restarting the IDE). If the setup is correct, you should see something like the below as the output:
+1. After that, locate the `src/main/java/lazysourcea/lazysourcea.java` file, right-click it, and choose `Run lazysourcea.main()` (if the code editor is showing compile errors, try restarting the IDE). If the setup is correct, you should see something like the below as the output:
    ```
    Hello from
     ____        _        

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ test {
 
 application {
     mainClass.set("lazysourcea.ui.javafx.Launcher")
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 shadowJar {

--- a/src/main/java/lazysourcea/lazysourcea.java
+++ b/src/main/java/lazysourcea/lazysourcea.java
@@ -11,7 +11,13 @@ import lazysourcea.task.TaskList;
 import lazysourcea.task.Todo;
 import lazysourcea.ui.Ui;
 
-
+/**
+ * Core engine for Lazysourcea: UI-agnostic and single-input driven, it loads and saves tasks via
+ * {@code Storage}, holds the in-memory {@code TaskList}, parses commands with {@code Parser}, and
+ * returns user-facing text for each call to {@link #getResponse(String)} (no printing or loops);
+ * {@link #getWelcomeMessage()} yields the startup greeting, and {@link #isExit()} flips to {@code true}
+ * after a "bye" command so the caller (e.g., JavaFX) can close the app.
+ */
 public class lazysourcea {
     // --- fields for shared core state ---
     private final Storage storage;
@@ -176,8 +182,9 @@ public class lazysourcea {
         case MARK:
             try {
                 int index = parser.parseIndex(parsed.arg, taskList.listSize());
+                assert index >= 0 && index < taskList.listSize() : "index out of bounds after parseIndex";
                 Task t = taskList.getTask(index);
-                t.isDone();
+                t.markDone();
                 storage.save(taskList.asList());
                 ui.showMarked(t);
             } catch (NumberFormatException | IndexOutOfBoundsException e) {
@@ -187,8 +194,9 @@ public class lazysourcea {
         case UNMARK:
             try {
                 int index = parser.parseIndex(parsed.arg, taskList.listSize());
+                assert index >= 0 && index < taskList.listSize() : "index out of bounds after parseIndex";
                 Task t = taskList.getTask(index);
-                t.isNotDone();
+                t.markNotDone();
                 storage.save(taskList.asList());
                 ui.showUnmarked(t);
             } catch (NumberFormatException | IndexOutOfBoundsException e) {

--- a/src/main/java/lazysourcea/storage/Storage.java
+++ b/src/main/java/lazysourcea/storage/Storage.java
@@ -80,7 +80,7 @@ public class Storage {
                     continue;
                 }
                 if (done) {
-                    t.isDone();
+                    t.markDone();
                 }
                 tasks.add(t);
             }

--- a/src/main/java/lazysourcea/task/Task.java
+++ b/src/main/java/lazysourcea/task/Task.java
@@ -35,14 +35,14 @@ public class Task {
     /**
      * Marks this task as completed.
      */
-    public void isDone() {
+    public void markDone() {
         this.isDone = true;
     }
 
     /**
      * Marks this task as not completed.
      */
-    public void isNotDone() {
+    public void markNotDone() {
         this.isDone = false;
     }
 

--- a/src/main/java/lazysourcea/task/TaskList.java
+++ b/src/main/java/lazysourcea/task/TaskList.java
@@ -36,6 +36,7 @@ public class TaskList {
      * @return the size of the task list
      */
     public int listSize() {
+        assert items.size() >= 0 : "size negative";
         return items.size();
     }
 

--- a/src/main/java/lazysourcea/ui/Ui.java
+++ b/src/main/java/lazysourcea/ui/Ui.java
@@ -53,6 +53,7 @@ public class Ui {
     }
 
     public void showError(String message) {
+        assert message != null : "error message null";
         out.accept(message);
     }
 
@@ -68,6 +69,7 @@ public class Ui {
     }
 
     public void showAdded(Task task, int size) {
+        assert size >= 0 : "size negative";
         out.accept("ok. task added:\n  " + task);
         out.accept("now you have " + size + " task(s) in the list.");
     }

--- a/src/test/java/lazysourcea/storage/StorageTest.java
+++ b/src/test/java/lazysourcea/storage/StorageTest.java
@@ -26,7 +26,7 @@ public class StorageTest {
         TaskList list = new TaskList();
         Task t1 = new Todo("read book");
         Task t2 = new Deadline("return book", LocalDate.of(2019, 12, 2));
-        t2.isDone();
+        t2.markDone();
         list.addTask(t1);
         list.addTask(t2);
 

--- a/src/test/java/lazysourcea/task/DeadlineTest.java
+++ b/src/test/java/lazysourcea/task/DeadlineTest.java
@@ -20,7 +20,7 @@ public class DeadlineTest {
     void toDataString_savesIsoDate() {
         Deadline d = new Deadline("return book", LocalDate.of(2019, 12, 2));
         assertEquals("D | 0 | return book | 2019-12-02", d.toDataString());
-        d.isDone();
+        d.markDone();
         assertEquals("D | 1 | return book | 2019-12-02", d.toDataString());
     }
 }


### PR DESCRIPTION
Introduced Java assertions throughout the core to catch programmer errors early. Assertions validate invariants such as non-null inputs, valid task indices, and correct parser outputs. Verified they can be enabled in IntelliJ using the `-ea` VM option.

Renamed Task methods for clarity:
- isDone() -> markDone()
- isNotDone() -> markNotDone()

These new names better reflect their side effects, distinguishing them from boolean getters.

Added a class-level Javadoc comment to lazysourcea summarizing its responsibilities, usage, and design (UI-agnostic core that parses commands, updates tasks, and returns reply strings).

Together, these changes improve code robustness, readability, and developer documentation.