### PR TITLE
Refactor(core): extract CommandExecutor; improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 /text-ui-test/ACTUAL.TXT
 text-ui-test/EXPECTED-UNIX.TXT
 /data/lazysourcea.txt
+/oldmethod

--- a/src/main/java/lazysourcea/lazysourcea.java
+++ b/src/main/java/lazysourcea/lazysourcea.java
@@ -10,142 +10,25 @@ import lazysourcea.task.Task;
 import lazysourcea.task.TaskList;
 import lazysourcea.task.Todo;
 import lazysourcea.ui.Ui;
+import lazysourcea.logic.CommandExecutor;
 
 /**
- * Core engine for Lazysourcea: UI-agnostic and single-input driven, it loads and saves tasks via
- * {@code Storage}, holds the in-memory {@code TaskList}, parses commands with {@code Parser}, and
- * returns user-facing text for each call to {@link #getResponse(String)} (no printing or loops);
- * {@link #getWelcomeMessage()} yields the startup greeting, and {@link #isExit()} flips to {@code true}
- * after a "bye" command so the caller (e.g., JavaFX) can close the app.
+ * UI-agnostic core orchestrator for Lazysourcea. Holds the persistent
+ * {@link Storage}, in-memory {@link TaskList}, and {@link Parser}. Each call
+ * to {@link #getResponse(String)} parses the input and delegates command
+ * handling to {@link CommandExecutor}, capturing user-facing lines through a
+ * {@code Consumer<String>} sink (no printing, no blocking loop) and returning
+ * the composed reply. Use {@link #getWelcomeMessage()} for the startup greeting,
+ * and check {@link #isExit()} after each call to detect a "bye" so the caller
+ * (e.g., JavaFX) can close the app.
  */
 public class lazysourcea {
     // --- fields for shared core state ---
     private final Storage storage;
     private final TaskList taskList;
     private final Parser parser;
+
     private boolean isExit = false;
-
-    /*
-    public static void main(String[] args) {
-        // Your original console loop (unchanged)
-        Storage storage = new Storage("data", "lazysourcea.txt");
-        TaskList taskList = new TaskList();
-        Ui ui = new Ui();
-        Parser parser = new Parser();
-
-        ArrayList<Task> loaded = storage.load();
-        for (Task t : loaded) {
-            taskList.addTask(t);
-        }
-
-        ui.showWelcome();
-        boolean running = true;
-
-        while (running) {
-            ui.prompt();
-            Parser.Parsed parsed = parser.parse(ui.readCommand());
-
-            switch (parsed.type) {
-                case BYE:
-                    ui.showBye();
-                    running = false;
-                    break;
-
-                case LIST:
-                    ui.showList(taskList);
-                    break;
-
-                case MARK:
-                    try {
-                        int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                        Task t = taskList.getTask(index);
-                        t.isDone();
-                        ui.showMarked(t);
-                        storage.save(taskList.asList());
-                    } catch (NumberFormatException | IndexOutOfBoundsException e) {
-                        ui.showError("invalid task number. use: mark <number>");
-                    }
-                    break;
-
-                case UNMARK:
-                    try {
-                        int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                        Task t = taskList.getTask(index);
-                        t.isNotDone();
-                        ui.showUnmarked(t);
-                        storage.save(taskList.asList());
-                    } catch (NumberFormatException | IndexOutOfBoundsException e) {
-                        ui.showError("invalid task number. use: unmark <number>");
-                    }
-                    break;
-
-                case TODO:
-                    if (parsed.arg.isEmpty()) {
-                        ui.showError("tsk.. todo description cannot empty.\nuse: todo <desc>");
-                    } else {
-                        Task todo = new Todo(parsed.arg);
-                        taskList.addTask(todo);
-                        ui.showAdded(todo, taskList.listSize());
-                        storage.save(taskList.asList());
-                    }
-                    break;
-
-                case DEADLINE:
-                    try {
-                        Parser.DeadlineArgs d = parser.parseDeadlineArgs(parsed.arg);
-                        Task deadline = new Deadline(d.desc, d.by);
-                        taskList.addTask(deadline);
-                        ui.showAdded(deadline, taskList.listSize());
-                        storage.save(taskList.asList());
-                    } catch (Exception e) {
-                        ui.showError("oi.. invalid deadline format.\nuse: deadline <desc> /by <time>"
-                                + "\naccepted: yyyy-MM-dd (e.g., 2019-10-15) or d/M/yyyy (e.g., 2/12/2019)");
-                    }
-                    break;
-
-                case EVENT:
-                    try {
-                        Parser.EventArgs ev = parser.parseEventArgs(parsed.arg);
-                        Task event = new Event(ev.desc, ev.from, ev.to);
-                        taskList.addTask(event);
-                        ui.showAdded(event, taskList.listSize());
-                        storage.save(taskList.asList());
-                    } catch (Exception e) {
-                        ui.showError("oi.. invalid event format.\nuse: event <desc> /from <time> /to <time>");
-                    }
-                    break;
-
-                case DELETE:
-                    try {
-                        int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                        Task removedTask = taskList.removeTask(index);
-                        ui.showDeleted(removedTask, taskList.listSize());
-                        storage.save(taskList.asList());
-                    } catch (NumberFormatException e) {
-                        ui.showError("oi.. give valid task number pls.\nUsage: delete <number>");
-                    } catch (IndexOutOfBoundsException e) {
-                        ui.showError("task number out of range lah.");
-                    }
-                    break;
-
-                case FIND:
-                    if (parsed.arg.isEmpty()) {
-                        ui.showError("usage: find <keyword>");
-                    } else {
-                        ui.showFindResults(taskList, parsed.arg);
-                    }
-                    break;
-
-                case HELP:
-                    ui.showHelp();
-                    break;
-
-                default:
-                    ui.showUnknownOrEmpty(parsed.raw);
-            }
-        }
-    }
-    */
 
     // --- JavaFX-friendly constructor (no console I/O) ---
     public lazysourcea(String dataDir, String fileName) {
@@ -167,103 +50,19 @@ public class lazysourcea {
         Parser.Parsed parsed = parser.parse(input);
 
         StringBuilder sb = new StringBuilder();
-        Ui ui = new Ui(line -> {
+        java.util.function.Consumer<String> out = line -> {
             if (line != null) sb.append(line).append(System.lineSeparator());
-        });
+        };
 
-        switch (parsed.type) {
-        case BYE:
-            ui.showBye();
-            this.isExit = true;
-            break;
-        case LIST:
-            taskList.listTasks(line -> sb.append(line).append('\n'));
-            break;
-        case MARK:
-            try {
-                int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                assert index >= 0 && index < taskList.listSize() : "index out of bounds after parseIndex";
-                Task t = taskList.getTask(index);
-                t.markDone();
-                storage.save(taskList.asList());
-                ui.showMarked(t);
-            } catch (NumberFormatException | IndexOutOfBoundsException e) {
-                ui.showError("invalid task number. use: mark <number>");
-            }
-            break;
-        case UNMARK:
-            try {
-                int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                assert index >= 0 && index < taskList.listSize() : "index out of bounds after parseIndex";
-                Task t = taskList.getTask(index);
-                t.markNotDone();
-                storage.save(taskList.asList());
-                ui.showUnmarked(t);
-            } catch (NumberFormatException | IndexOutOfBoundsException e) {
-                ui.showError("invalid task number. use: unmark <number>");
-            }
-            break;
-        case TODO:
-            if (parsed.arg.isEmpty()) {
-                ui.showError("tsk.. todo description cannot empty.\nuse: todo <desc>");
-            } else {
-                Task todo = new Todo(parsed.arg);
-                taskList.addTask(todo);
-                storage.save(taskList.asList());
-                ui.showAdded(todo, taskList.listSize());
-            }
-            break;
-        case DEADLINE:
-            try {
-                Parser.DeadlineArgs d = parser.parseDeadlineArgs(parsed.arg);
-                Task deadline = new Deadline(d.desc, d.by);
-                taskList.addTask(deadline);
-                storage.save(taskList.asList());
-                ui.showAdded(deadline, taskList.listSize());
-            } catch (Exception e) {
-                ui.showError("oi.. invalid deadline format.\nuse: deadline <desc> /by <time>"
-                        + "\naccepted: yyyy-MM-dd (e.g., 2019-10-15) or d/M/yyyy (e.g., 2/12/2019)");
-            }
-            break;
-        case EVENT:
-            try {
-                Parser.EventArgs ev = parser.parseEventArgs(parsed.arg);
-                Task event = new Event(ev.desc, ev.from, ev.to);
-                taskList.addTask(event);
-                storage.save(taskList.asList());
-                ui.showAdded(event, taskList.listSize());
-            } catch (Exception e) {
-                ui.showError("oi.. invalid event format.\nuse: event <desc> /from <time> /to <time>");
-            }
-            break;
-        case DELETE:
-            try {
-                int index = parser.parseIndex(parsed.arg, taskList.listSize());
-                Task removed = taskList.removeTask(index);
-                storage.save(taskList.asList());
-                ui.showDeleted(removed, taskList.listSize());
-            } catch (NumberFormatException e) {
-                ui.showError("oi.. give valid task number pls.\nUsage: delete <number>");
-            } catch (IndexOutOfBoundsException e) {
-                ui.showError("task number out of range lah.");
-            }
-            break;
-        case FIND:
-            if (parsed.arg.isEmpty()) {
-                ui.showError("usage: find <keyword>");
-            } else {
-                ui.showFindResults(taskList, parsed.arg);
-            }
-            break;
-        case HELP:
-            ui.showHelp();
-            break;
-        default:
-            ui.showUnknownOrEmpty(parsed.raw == null ? "" : parsed.raw);
-        }
+        CommandExecutor exec =
+                new CommandExecutor(taskList, storage, parser, out);
+
+        boolean exit = exec.execute(parsed, out);
+        this.isExit = exit;
 
         return sb.toString().trim();
     }
+
 
 
     /** For JavaFX to check if it should close the window after showing the reply. */

--- a/src/main/java/lazysourcea/logic/CommandExecutor.java
+++ b/src/main/java/lazysourcea/logic/CommandExecutor.java
@@ -1,0 +1,143 @@
+package lazysourcea.logic;
+
+import java.util.function.Consumer;
+
+import lazysourcea.parser.Parser;
+import lazysourcea.storage.Storage;
+import lazysourcea.task.*;
+import lazysourcea.ui.Ui;
+
+/**
+ * Executes a single parsed command against the current application state.
+ * <p>
+ * This class is UI-agnostic: it formats user-facing output via {@link Ui},
+ * which writes to a provided {@code Consumer<String>} sink. It may mutate
+ * {@link TaskList} and persist changes through {@link Storage}. Use the
+ * boolean return of {@link #execute(Parser.Parsed, Consumer)} to detect
+ * an exit request (i.e., {@code bye}).
+ */
+public class CommandExecutor {
+    private final TaskList taskList;
+    private final Storage storage;
+    private final Parser parser;
+    private final Ui ui;
+
+    /**
+     * Creates a command executor that writes user-visible lines to the given
+     * output sink.
+     *
+     * @param taskList the in-memory task list to read/mutate
+     * @param storage  the storage used to persist mutations
+     * @param parser   helper for parsing indices and sub-arguments
+     * @param out      sink that receives formatted output lines
+     *                 (e.g., collected for JavaFX rendering)
+     */
+    public CommandExecutor(TaskList taskList, Storage storage, Parser parser, Consumer<String> out) {
+        this.taskList = taskList;
+        this.storage = storage;
+        this.parser = parser;
+        this.ui = new Ui(out);
+    }
+
+    /**
+     * Executes one parsed command, emitting formatted lines to the configured
+     * output sink. Mutating commands save the task list to storage. Errors are
+     * reported as human-friendly messages; exceptions are handled internally.
+     *
+     * @param parsed     the already-parsed command and its argument(s)
+     * @param outForList sink to receive each line of {@code list} output
+     *                   (forwarded to {@link TaskList#listTasks(Consumer)})
+     * @return {@code true} if the command requests program exit (BYE),
+     *         {@code false} otherwise
+     */
+    public boolean execute(Parser.Parsed parsed, Consumer<String> outForList) {
+        switch (parsed.type) {
+            case BYE:
+                ui.showBye();
+                return true;
+            case LIST:
+                taskList.listTasks(outForList);
+                return false;
+            case MARK:
+                try {
+                    int index = parser.parseIndex(parsed.arg, taskList.listSize());
+                    Task t = taskList.getTask(index);
+                    t.markDone();
+                    storage.save(taskList.asList());
+                    ui.showMarked(t);
+                } catch (NumberFormatException | IndexOutOfBoundsException e) {
+                    ui.showError("invalid task number. use: mark <number>");
+                }
+                return false;
+            case UNMARK:
+                try {
+                    int index = parser.parseIndex(parsed.arg, taskList.listSize());
+                    Task t = taskList.getTask(index);
+                    t.markNotDone();
+                    storage.save(taskList.asList());
+                    ui.showUnmarked(t);
+                } catch (NumberFormatException | IndexOutOfBoundsException e) {
+                    ui.showError("invalid task number. use: unmark <number>");
+                }
+                return false;
+            case TODO:
+                if (parsed.arg.isEmpty()) {
+                    ui.showError("tsk.. todo description cannot empty.\nuse: todo <desc>");
+                } else {
+                    Task todo = new Todo(parsed.arg);
+                    taskList.addTask(todo);
+                    storage.save(taskList.asList());
+                    ui.showAdded(todo, taskList.listSize());
+                }
+                return false;
+            case DEADLINE:
+                try {
+                    Parser.DeadlineArgs d = parser.parseDeadlineArgs(parsed.arg);
+                    Task deadline = new Deadline(d.desc, d.by);
+                    taskList.addTask(deadline);
+                    storage.save(taskList.asList());
+                    ui.showAdded(deadline, taskList.listSize());
+                } catch (Exception e) {
+                    ui.showError("oi.. invalid deadline format.\nuse: deadline <desc> /by <time>"
+                            + "\naccepted: yyyy-MM-dd (e.g., 2019-10-15) or d/M/yyyy (e.g., 2/12/2019)");
+                }
+                return false;
+            case EVENT:
+                try {
+                    Parser.EventArgs ev = parser.parseEventArgs(parsed.arg);
+                    Task event = new Event(ev.desc, ev.from, ev.to);
+                    taskList.addTask(event);
+                    storage.save(taskList.asList());
+                    ui.showAdded(event, taskList.listSize());
+                } catch (Exception e) {
+                    ui.showError("oi.. invalid event format.\nuse: event <desc> /from <time> /to <time>");
+                }
+                return false;
+            case DELETE:
+                try {
+                    int index = parser.parseIndex(parsed.arg, taskList.listSize());
+                    Task removed = taskList.removeTask(index);
+                    storage.save(taskList.asList());
+                    ui.showDeleted(removed, taskList.listSize());
+                } catch (NumberFormatException e) {
+                    ui.showError("oi.. give valid task number pls.\nUsage: delete <number>");
+                } catch (IndexOutOfBoundsException e) {
+                    ui.showError("task number out of range lah.");
+                }
+                return false;
+            case FIND:
+                if (parsed.arg.isEmpty()) {
+                    ui.showError("usage: find <keyword>");
+                } else {
+                    ui.showFindResults(taskList, parsed.arg);
+                }
+                return false;
+            case HELP:
+                ui.showHelp();
+                return false;
+            default:
+                ui.showUnknownOrEmpty(parsed.raw == null ? "" : parsed.raw);
+                return false;
+        }
+    }
+}

--- a/src/main/java/lazysourcea/task/TaskList.java
+++ b/src/main/java/lazysourcea/task/TaskList.java
@@ -3,6 +3,7 @@ package lazysourcea.task;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Represents a mutable list of {@link Task} objects.
@@ -90,7 +91,12 @@ public class TaskList {
         }
     }
 
-    public void listTasks(java.util.function.Consumer<String> out) {
+    /**
+     * Prints all tasks in the list to standard output.
+     * <p>
+     * If the list is empty, a placeholder message is shown.
+     */
+    public void listTasks(Consumer<String> out) {
         if (listSize() == 0) {
             out.accept("(no tasks yet)");
             return;

--- a/src/main/java/lazysourcea/ui/Ui.java
+++ b/src/main/java/lazysourcea/ui/Ui.java
@@ -31,6 +31,9 @@ public class Ui {
                          |___/
             """;
 
+    /**
+     * Shows the welcome message.
+     */
     public void showWelcome() {
         //out.accept("Hello from\n" + LOGO);
         //out.accept("-----------------------");
@@ -39,6 +42,9 @@ public class Ui {
         out.accept("enter help for available commands");
     }
 
+    /**
+     * Show the bye message.
+     */
     public void showBye() {
         out.accept("bye.");
     }
@@ -52,11 +58,18 @@ public class Ui {
         return scanner.nextLine().trim();
     }
 
+    /**
+     * Shows the error message for any wrongly formatted user input.
+     * @param message the specific error message to display
+     */
     public void showError(String message) {
         assert message != null : "error message null";
         out.accept(message);
     }
 
+    /**
+     * Shows the help menu.
+     */
     public void showHelp() {
         out.accept("list:           shows your tasklist");
         out.accept("todo:           adds a todo task. use: todo <desc>");
@@ -68,22 +81,40 @@ public class Ui {
         out.accept("bye:            exits the program");
     }
 
+    /**
+     * Shows the task added.
+     * @param task the task that was added to the list
+     * @param size the size of the task list after addition
+     */
     public void showAdded(Task task, int size) {
         assert size >= 0 : "size negative";
         out.accept("ok. task added:\n  " + task);
         out.accept("now you have " + size + " task(s) in the list.");
     }
 
+    /**
+     * Shows the task removed.
+     * @param task the task that was removed from the list
+     * @param size the size of the task list after deletion
+     */
     public void showDeleted(Task task, int size) {
         out.accept("task:");
         out.accept("  " + task + "\nremoved.");
         out.accept("now you have " + size + " tasks in the list.");
     }
 
+    /**
+     * Shows the marked task.
+     * @param task the task to be marked
+     */
     public void showMarked(Task task) {
         out.accept("task marked as done:\n " + task);
     }
 
+    /**
+     * Shows the unmarked task.
+     * @param task the task to be unmarked
+     */
     public void showUnmarked(Task task) {
         out.accept("task unmarked:\n " + task);
     }
@@ -93,6 +124,11 @@ public class Ui {
         // If you want this to also funnel through the sink, change TaskList to call a Consumer too.
     }
 
+    /**
+     * Shows the tasks that matches the keyword entered by the user.
+     * @param taskList the list of tasks
+     * @param keyword the keyword to be matched to the tasks
+     */
     public void showFindResults(TaskList taskList, String keyword) {
         out.accept("ok found matches:");
         int index = 1;
@@ -108,6 +144,10 @@ public class Ui {
         }
     }
 
+    /**
+     * Shows the message if the user input is either empty or unknown.
+     * @param raw the user input
+     */
     public void showUnknownOrEmpty(String raw) {
         if (!raw.isEmpty()) {
             out.accept("tsk what u saying. i don't understand");


### PR DESCRIPTION
Move command-handling logic out of lazysourcea#getResponse into a new lazysourcea.logic.CommandExecutor. The core now parses input, delegates to the executor, captures output via a Consumer<String> sink, and returns the composed reply. Exit behavior is unchanged; BYE still flips isExit() for the caller.

CommandExecutor executes one parsed command, mutates TaskList as needed, persists via Storage, and formats user-facing lines through Ui. LIST routes its lines through TaskList.listTasks(Consumer<String>). Errors are reported as friendly messages; exceptions are handled internally.

Docs and quality:
- Add Javadoc to TaskList.listTasks(Consumer<String> out).
- Add Javadoc comments to methods in Ui.java.
- Update class-level Javadoc for lazysourcea to reflect delegation and UI-agnostic design.
- General cleanups and small readability improvements.